### PR TITLE
Typo on seed z0 check.

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function getLocked (geom, limits) {
         }
     } else {
         var seed = tilebelt.bboxToTile(extent(geom));
-        if (!seed[3]) seed = [0, 0, 0];
+        if (!seed[2]) seed = [0, 0, 0];
         splitSeek(seed, geom, locked, limits);
         locked = mergeTiles(locked, limits);
     }


### PR DESCRIPTION
`tile[3]` is never set -- assuming this is meant to force 0/0/0 if the seed tile is ever at z0.
