### PR TITLE
Add missing require to the example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ npm install tile-cover
 ### Usage
 
 ```js
+var cover = require('tile-cover');
 var poly = JSON.parse(fs.readFileSync('./poly.geojson'));
 var limits = {
   	min_zoom: 4,


### PR DESCRIPTION
The example reads better with the `require`. @morganherlocker, please 👀 and merge.