### PR TITLE
fix crash for max zoom 12 or more

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,10 +166,10 @@ function polygonCover(tileHash, tileArray, geom, zoom) {
 
     intersections.sort(compareTiles); // sort by y, then x
 
-    for (i = 0; i < intersections.length; i += 2) {
+    for (i = 1; i < intersections.length; i += 2) { 
         // fill tiles between pairs of intersections
-        y = intersections[i][1];
-        for (var x = intersections[i][0] + 1; x < intersections[i + 1][0]; x++) {
+        y = intersections[i-1][1];
+        for (var x = intersections[i-1][0] + 1; x < intersections[i][0]; x++) {
             var id = toID(x, y, zoom);
             if (!tileHash[id]) {
                 tileArray.push([x, y, zoom]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/tile-cover",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "generate the minimum number of tiles to cover a geojson geometry",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
When selecting max_zoom of 12 or more 
we get odd number of intersections, which causes exception
when trying to read index i+1 which is out of the array bounds  